### PR TITLE
Add a misisng \ in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ In `app/Console/Kernel.php` you should schedule the `VineVax\UptimeRobotTile\Com
     
         protected function schedule(Schedule $schedule)
         {
-            $schedule->command(VineVax\UptimeRobotTile\Commands\FetchUptimeRobotDataCommand::class)->everyFiveMinutes();
+            $schedule->command(\VineVax\UptimeRobotTile\Commands\FetchUptimeRobotDataCommand::class)->everyFiveMinutes();
         }
 ````
 


### PR DESCRIPTION
Without the \ it will try to search for the class App\Console\VineVax\UptimeRobotTile\Commands\FetchUptimeRobotDataCommand